### PR TITLE
Unified string generation for macos

### DIFF
--- a/extension/js/UAGenerator.js
+++ b/extension/js/UAGenerator.js
@@ -86,8 +86,7 @@ var UAGenerator = function() {
       v6up: ['Windows NT 6\\.[0-3]', 'Windows NT 10\\.0']
     },
     macos: {
-      v10_8:   ['Intel Mac OS X 10_8_[2-8]', 'Intel Mac OS X 10\\.8\\.[2-8]'],
-      v10_8up: ['Intel Mac OS X 10_(1|)[6-9]_[2-8]', 'Intel Mac OS X 10\\.(1|)[6-9]\\.[2-8]']
+      v10: ['Intel Mac OS X 10([._])(9|1[0-3])\\1[0-4]']
     },
     linux: {
       bit32: ['(NetBSD amd64|Linux amd64|Ubuntu\\; Linux|SunOS sun4u|Gentoo)'],
@@ -135,7 +134,7 @@ var UAGenerator = function() {
       },
       mac: {
         name: 'Chrome on Mac',
-        regexp: ['Mozilla\\/5\\.0 \\(Macintosh\\; ' + this.get(this.patterns.macos.v10_8up) + '\\) ' + this.get(this.patterns.applewebkit) + ' \\(KHTML, like Gecko\\) Chrome\\/(' + this.get(this.patterns.browsers_versions.chrome) + ') Safari\\/(\\2)']
+        regexp: ['Mozilla\\/5\\.0 \\(Macintosh\\; ' + this.get(this.patterns.macos.v10) + '\\) ' + this.get(this.patterns.applewebkit) + ' \\(KHTML, like Gecko\\) Chrome\\/(' + this.get(this.patterns.browsers_versions.chrome) + ') Safari\\/(\\2)']
       },
       linux: {
         name: 'Chrome on Linux',
@@ -149,7 +148,7 @@ var UAGenerator = function() {
       },
       mac: {
         name: 'Firefox on Mac',
-        regexp: ['Mozilla\\/5\\.0 \\(Macintosh\\;( U\\; | )' + this.get(this.patterns.macos.v10_8up) + '\\; rv:(' + this.get(this.patterns.browsers_versions.firefox) + ')\\) Gecko\\/20100101 Firefox\\/(\\3)']
+        regexp: ['Mozilla\\/5\\.0 \\(Macintosh\\;( U\\; | )' + this.get(this.patterns.macos.v10) + '\\; rv:(' + this.get(this.patterns.browsers_versions.firefox) + ')\\) Gecko\\/20100101 Firefox\\/(\\3)']
       },
       linux: {
         name: 'Firefox on Linux',
@@ -163,7 +162,7 @@ var UAGenerator = function() {
       },
       mac: {
         name: 'Safari on Mac',
-        regexp: ['Mozilla\\/5\\.0 \\(Macintosh\\;( U\\; | )' + this.get(this.patterns.macos.v10_8up) + '\\; ' + this.get(this.patterns.locales) + '\\) ' + this.get(this.patterns.applewebkit) + ' \\(KHTML, like Gecko\\) Version\\/' + this.get(this.patterns.browsers_versions.safari) + ' Safari\\/(\\4)']
+        regexp: ['Mozilla\\/5\\.0 \\(Macintosh\\;( U\\; | )' + this.get(this.patterns.macos.v10) + '\\; ' + this.get(this.patterns.locales) + '\\) ' + this.get(this.patterns.applewebkit) + ' \\(KHTML, like Gecko\\) Version\\/' + this.get(this.patterns.browsers_versions.safari) + ' Safari\\/(\\4)']
       },
       linux: {
         name: 'Safari on Linux',
@@ -185,7 +184,7 @@ var UAGenerator = function() {
       },
       mac: {
         name: 'Opera on Mac',
-        regexp: ['Mozilla\\/5\\.0 \\(Macintosh\\; ' + this.get(this.patterns.macos.v10_8up) + '\\) ' + this.get(this.patterns.applewebkit) + ' \\(KHTML, like Gecko\\) Chrome\\/(' + this.get(this.patterns.browsers_versions.chrome) + ') Safari\\/(\\2) OPR/' + this.get(this.patterns.browsers_versions.opera)]
+        regexp: ['Mozilla\\/5\\.0 \\(Macintosh\\; ' + this.get(this.patterns.macos.v10) + '\\) ' + this.get(this.patterns.applewebkit) + ' \\(KHTML, like Gecko\\) Chrome\\/(' + this.get(this.patterns.browsers_versions.chrome) + ') Safari\\/(\\2) OPR/' + this.get(this.patterns.browsers_versions.opera)]
       },
       linux: {
         name: 'Opera on Linux',


### PR DESCRIPTION
In response to #11. Current browsers require at least macos 10.9. Also unified the _/. separator issue with a backreference.