### PR TITLE
Fixing race condition for navigator.userAgent

### DIFF
--- a/extension/html/background.html
+++ b/extension/html/background.html
@@ -9,6 +9,7 @@
     <script type="text/javascript" src="../js/API.js"></script>
     <script type="text/javascript" src="../js/hooks/onBeforeSendHeaders.js"></script>
     <script type="text/javascript" src="../js/hooks/onMessage.js"></script>
+    <script type="text/javascript" src="../js/hooks/onHeadersReceived.js"></script>
     <script type="text/javascript" src="../js/pages/background.js"></script>
     <title></title>
   </head>

--- a/extension/js/hooks/onHeadersReceived.js
+++ b/extension/js/hooks/onHeadersReceived.js
@@ -1,0 +1,45 @@
+/* global chrome, API */
+
+/**
+ * This file is part of Random User-Agent Browser Extension
+ * @link https://github.com/tarampampam/random-user-agent
+ *
+ * Everyone is permitted to copy and distribute verbatim or modified copies of this license
+ * document, and changing it is allowed as long as the name is changed.
+ *
+ * DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE TERMS AND CONDITIONS FOR COPYING,
+ * DISTRIBUTION AND MODIFICATION
+ *
+ * 0. You just DO WHAT THE FUCK YOU WANT TO.
+ */
+
+"use strict";
+
+/**
+ * Hook for cookie injection
+ */
+ 
+chrome.webRequest.onHeadersReceived.addListener(function(details) {
+
+  //                 !!! IMPORTANT !!!
+  // --------------------------------------------------
+  // chrome.runtime.sendMessage API does not works here
+  // --------------------------------------------------
+  //                 !!! IMPORTANT !!!
+
+  if (API.settings.getEnabled() === true && API.settings.getJavascriptProtectionEnabled()) {
+    var useragent = API.useragent.get();
+    if (typeof useragent === 'string') {
+      // Make wildcard search in exceptions list
+      //console.log('Catch URI "' + details.url + '"');
+
+      if (API.exceptions.uriMatch({uri: details.url})) {
+        console.info('Ignore URI "' + details.url + '"');
+        return;
+      }
+
+      details.responseHeaders.push({ name: "Set-Cookie", value: 'RUA_TRANSPORT_COOKIE=' + encodeURIComponent(useragent) + ';' });
+      return { responseHeaders: details.responseHeaders };
+    }
+  }
+}, {urls: ["<all_urls>"]}, ["blocking", "responseHeaders"]);

--- a/extension/js/inject/content.js
+++ b/extension/js/inject/content.js
@@ -35,8 +35,7 @@ chrome.runtime.sendMessage([
       if (typeof useragent === 'string' && useragent !== '') {
         if (uri_match === false) {
           consoleMessage('Use fake User-Agent: ' + useragent);
-          var d = document.documentElement,
-                injection_code = '(' + function(new_useragent) {
+          var injection_code = '(' + function(new_useragent) {
                 if (typeof window === 'object' && typeof window.navigator === 'object') {
                   navigator = Object.create(window.navigator);
                   Object.defineProperties(navigator, {
@@ -48,9 +47,10 @@ chrome.runtime.sendMessage([
                   });
                 }
               } + ')("' + useragent.replace(/([\"\'])/g, '\\$1') + '");';
-          d.setAttribute('onreset', injection_code);
-          d.dispatchEvent(new CustomEvent('reset'));
-          d.removeAttribute('onreset');
+          var script = document.createElement('script');
+          script.textContent = injection_code;
+          document.documentElement.appendChild(script);
+          script.remove();
           if (typeof navigator === 'object') {
             Object.defineProperties(navigator, {
               userAgent:  {get: function() {return useragent;}},

--- a/extension/js/inject/content.js
+++ b/extension/js/inject/content.js
@@ -15,52 +15,42 @@
  * 0. You just DO WHAT THE FUCK YOU WANT TO.
  */
 
-chrome.runtime.sendMessage([
-  {action: 'settings.getEnabled'},
-  {action: 'settings.getJavascriptProtectionEnabled'},
-  {action: 'useragent.get'},
-  {action: 'exceptions.uriMatch', data: {uri: window.location.href}} // Make wildcard search in exceptions list
-], function(results) {
-  var enabled = results[0],
-    js_protection_enabled = results[1],
-    useragent = results[2],
-    uri_match = results[3];
-  var consoleMessage = function (message_text) {
-    if (typeof message_text === 'string') {
-      console.debug('%c [Random User-Agent] '+message_text+' ', 'background: transparent; color: rgba(0,0,0,0.45)');
+function getCookie(cookie)
+{
+  return document.cookie.split(';').reduce(function(prev, c) {
+    var arr = c.split('=');
+    return (arr[0].trim() === cookie) ? decodeURIComponent(arr[1]) : prev;
+  }, undefined);
+}
+
+var userAgent=getCookie('RUA_TRANSPORT_COOKIE');
+document.cookie = 'RUA_TRANSPORT_COOKIE=; expires=Thu, 01 Jan 1970 00:00:00 UTC;';
+
+if (userAgent)
+{
+  var injection_code = '(' + function(new_useragent) {
+    if (typeof window === 'object' && typeof window.navigator === 'object') {
+      navigator = Object.create(window.navigator);
+      Object.defineProperties(navigator, {
+        userAgent: {get: function() {return new_useragent;}},
+        appVersion: {get: function() {return new_useragent;}}
+      });
+      Object.defineProperty(window, 'navigator', {
+        value: navigator, configurable: false, enumerable: false, writable: false
+      });
     }
-  };
-  if (enabled === true) {
-    if (js_protection_enabled === true) {
-      if (typeof useragent === 'string' && useragent !== '') {
-        if (uri_match === false) {
-          consoleMessage('Use fake User-Agent: ' + useragent);
-          var injection_code = '(' + function(new_useragent) {
-                if (typeof window === 'object' && typeof window.navigator === 'object') {
-                  navigator = Object.create(window.navigator);
-                  Object.defineProperties(navigator, {
-                    userAgent:  {get: function() {return new_useragent;}},
-                    appVersion: {get: function() {return new_useragent;}}
-                  });
-                  Object.defineProperty(window, 'navigator', {
-                    value: navigator, configurable: false, enumerable: false, writable: false
-                  });
-                }
-              } + ')("' + useragent.replace(/([\"\'])/g, '\\$1') + '");';
-          var script = document.createElement('script');
-          script.textContent = injection_code;
-          document.documentElement.appendChild(script);
-          script.remove();
-          if (typeof navigator === 'object') {
-            Object.defineProperties(navigator, {
-              userAgent:  {get: function() {return useragent;}},
-              appVersion: {get: function() {return useragent;}}
-            });
-          }
-        }
-      }
-    } else {
-      consoleMessage('User-Agent JavaScript protection disabled!');
-    }
+  } + ')("' + userAgent.replace(/([\"\'])/g, '\\$1') + '");';
+
+  var script = document.createElement('script');
+  script.textContent = injection_code;
+  document.documentElement.appendChild(script);
+
+  script.remove();
+
+  if (typeof navigator === 'object') {
+    Object.defineProperties(navigator, {
+      userAgent: {get: function() {return userAgent;}},
+      appVersion: {get: function() {return userAgent;}}
+    });
   }
-});
+}


### PR DESCRIPTION
This is a supposed fix for #26. The basic idea is to replace the current asynchronous implementation (via `sendMessage()`) in _content.js_ with a synchronous one (directly accessing the agent string via a temporary cookie set in `onHeadersReceived`), thus avoiding the race condition.

As this required a rather major refactoring of _content.js_ this PR should be thoroughly reviewed and tested.

**This PR also includes the changes of #25**