### PR TITLE
Settings saving button added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 ### Added
 
 - Chinese `zh_CN` localization (thanks to [@yfdyh000](https://github.com/yfdyh000))
+- "Save changes" button on the options page
+
+### Changed
+
+- Custom user-agent list on the settings page now limited (maximal `4096` symbols are allowed, [the reason is QUOTA_BYTES_PER_ITEM](https://developer.chrome.com/docs/extensions/reference/storage/#property-sync))
+
+### Fixed
+
+- `extraHeaders` options bug for `onHeadersReceived` hook in FireFox
 
 ## v3.2.0
 

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -41,6 +41,8 @@
   "previous_settings": {"message": "Previous settings"},
   "remove": {"message": "Remove"},
   "previous_settings_hint": {"message": "These settings were used by you on the previous extension version. Keep it somewhere or remove"},
+  "save_changes": {"message": "Save changes"},
+  "error_occurred": {"message": "Error occurred"},
 
   "edge_win": {"message": "Edge on Windows"},
   "chrome_win": {"message": "Chrome on Windows"},

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -41,6 +41,8 @@
   "previous_settings": {"message": "Предыдущие настройки"},
   "remove": {"message": "Удалить"},
   "previous_settings_hint": {"message": "Эти настройки использовались для предыдущей версии расширения. Сохраните их где-нибудь или удалите"},
+  "save_changes": {"message": "Сохранить изменения"},
+  "error_occurred": {"message": "Произошла ошибка"},
 
   "edge_win": {"message": "Edge на Windows"},
   "chrome_win": {"message": "Chrome на Windows"},

--- a/public/_locales/vi/messages.json
+++ b/public/_locales/vi/messages.json
@@ -41,6 +41,8 @@
   "previous_settings": {"message": "Cài đặt trước"},
   "remove": {"message": "Xóa"},
   "previous_settings_hint": {"message": "Các cài đặt này đã được bạn sử dụng trên phiên bản mở rộng trước đó. Giữ nó ở đâu đó hoặc loại bỏ"},
+  "save_changes": {"message": "Lưu thay đổi"},
+  "error_occurred": {"message": "Xảy ra lỗi"},
 
   "edge_win": {"message": "Edge trên Windows"},
   "chrome_win": {"message": "Chrome trên Windows"},

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -41,6 +41,8 @@
   "previous_settings": {"message": "以前的设置"},
   "remove": {"message": "移除"},
   "previous_settings_hint": {"message": "这是您在本扩展的早期版本中使用的设置。自行备份或移除它们"},
+  "save_changes": {"message": "保存更改"},
+  "error_occurred": {"message": "发生错误"},
 
   "edge_win": {"message": "Edge 于 Windows"},
   "chrome_win": {"message": "Chrome 于 Windows"},

--- a/src/view/components/options/list-textarea.vue
+++ b/src/view/components/options/list-textarea.vue
@@ -5,6 +5,7 @@
       <textarea :id="id"
                 :rows="rowsCount"
                 :placeholder="placeholder"
+                :maxlength="maxlength"
                 @input="checkValue">{{ lines }}</textarea>
       <p class="hint" v-if="hint">{{ hint }}</p>
     </div>
@@ -27,6 +28,7 @@ export default defineComponent({
     },
     placeholder: String,
     hint: String,
+    maxlength: Number,
   },
   emits: {
     change(text: string[] | any): boolean {

--- a/src/view/components/popup/overlay-alert.vue
+++ b/src/view/components/popup/overlay-alert.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="alert" @click="$emit('click')">
+    <div class="message">
+      <h1>{{ caption }}</h1>
+      <h2>{{ message }}</h2>
+    </div>
+    <div class="overlay"></div>
+  </div>
+</template>
+
+<script lang="ts">
+import {defineComponent} from 'vue'
+
+export default defineComponent({
+  components: {},
+  props: {
+    caption: String,
+    message: String,
+  },
+  emits: ['click'],
+})
+</script>
+
+<style lang="scss" scoped>
+.alert {
+  position: fixed;
+  width: 100vw;
+  height: 100vh;
+  top: 0;
+  left: 0;
+
+  .message {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 1;
+
+    h1, h2 {
+      text-align: center;
+    }
+  }
+
+  .overlay {
+    position: absolute;
+    background-color: var(--options-main-bg-color);
+    backdrop-filter: blur(8px);
+    opacity: .6;
+    top: 0;
+    width: 100%;
+    height: 100%;
+  }
+}
+</style>

--- a/src/view/options.vue
+++ b/src/view/options.vue
@@ -1,186 +1,227 @@
 <template>
-  <h1>{{ i18n('general_settings', 'General settings') }}</h1>
+  <overlay-alert :caption="'⛔ ' + i18n('error_occurred', 'Error occurred')"
+                 :message="error.message"
+                 @click="error.visible = false"
+                 v-if="error.visible"/>
 
-  <p>{{ i18n('general_settings_hint', 'Change the behavior of the switcher to best fit your needs') }}:</p>
+  <article>
+    <h1>
+      {{ i18n('general_settings', 'General settings') }}
+      <input type="button"
+             class="save-btn"
+             v-if="saveButtons.general"
+             :value="i18n('save_changes', 'Save changes')"
+             @click="save"/>
+    </h1>
 
-  <ul class="list">
-    <list-checkbox :checked="enabled"
-                   :caption="i18n('enable_switcher', 'Enable Switcher')"
-                   @change="saveEnabled"/>
-    <list-checkbox :checked="renew_enabled"
-                   :caption="i18n('auto_renew', 'Automatically change the User-Agent after specified period of time')"
-                   @change="saveRenewEnabled"/>
-    <list-number :value="Math.round(renew_intervalMillis / 1000)"
-                 :caption="i18n('auto_renew_interval', 'Time (in seconds) to automatically update the User-Agent (e.g. 1 hour = 3600)')"
-                 :minimum="1"
-                 :maximum="86400"
-                 :placeholder="60"
-                 @change="saveRenewInterval"/>
-    <list-checkbox :checked="renew_onStartup"
-                   :caption="i18n('auto_renew_on_startup', 'Change User-Agent on browser startup')"
-                   @change="saveRenewOnStartup"/>
-    <list-checkbox :checked="jsProtection_enabled"
-                   :caption="i18n('js_protection', 'Protect against detection by JavaScript')"
-                   @change="saveJsProtectionEnabled"/>
-    <list-checkbox :checked="customUseragent_enabled"
-                   :caption="i18n('custom_useragent', 'Use one of (in the randomized order) custom User-Agent instead generated')"
-                   @change="saveCustomUseragentEnabled"/>
-    <list-textarea :value="customUseragent_list"
-                   :caption="i18n('custom_useragent_list', 'Custom User-Agents (set a specific User-Agents, one per line)') + ':'"
-                   placeholder="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7; rv:92.0) Gecko/20010101 Firefox/92.0"
-                   @change="saveCustomUseragentList"/>
-  </ul>
+    <p>{{ i18n('general_settings_hint', 'Change the behavior of the switcher to best fit your needs') }}:</p>
 
-  <h2>{{ i18n('generator_settings', 'Generator settings') }}</h2>
+    <ul class="list">
+      <list-checkbox :checked="settings.enabled"
+                     :caption="i18n('enable_switcher', 'Enable Switcher')"
+                     @change="value => {settings.enabled = value; saveButtons.general = true}"/>
+      <list-checkbox :checked="settings.renew.enabled"
+                     :caption="i18n('auto_renew', 'Automatically change the User-Agent after specified period of time')"
+                     @change="value => {settings.renew.enabled = value; saveButtons.general = true}"/>
+      <list-number :value="Math.round(settings.renew.intervalMillis / 1000)"
+                   :caption="i18n('auto_renew_interval', 'Time (in seconds) to automatically update the User-Agent (e.g. 1 hour = 3600)')"
+                   :minimum="1"
+                   :maximum="86400"
+                   :placeholder="60"
+                   @change="value => {settings.renew.intervalMillis = Math.round(value * 1000); saveButtons.general = true}"/>
+      <list-checkbox :checked="settings.renew.onStartup"
+                     :caption="i18n('auto_renew_on_startup', 'Change User-Agent on browser startup')"
+                     @change="value => {settings.renew.onStartup = value; saveButtons.general = true}"/>
+      <list-checkbox :checked="settings.jsProtection.enabled"
+                     :caption="i18n('js_protection', 'Protect against detection by JavaScript')"
+                     @change="value => {settings.jsProtection.enabled = value; saveButtons.general = true}"/>
+      <list-checkbox :checked="settings.customUseragent.enabled"
+                     :caption="i18n('custom_useragent', 'Use one of (in the randomized order) custom User-Agent instead generated')"
+                     @change="value => {settings.customUseragent.enabled = value; saveButtons.general = true}"/>
+      <!-- Length limitation reason: <https://github.com/tarampampam/random-user-agent/issues/172> -->
+      <list-textarea :value="settings.customUseragent.list"
+                     :caption="i18n('custom_useragent_list', 'Custom User-Agents (set a specific User-Agents, one per line)') + ':'"
+                     :maxlength="4096"
+                     placeholder="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7; rv:92.0) Gecko/20010101 Firefox/92.0"
+                     @change="value => {settings.customUseragent.list = value; saveButtons.general = true}"/>
+    </ul>
 
-  <p>{{ i18n('generator_settings_hint', 'Here you can change the agent switching behavior') }}:</p>
+    <h2>
+      {{ i18n('generator_settings', 'Generator settings') }}
+      <input type="button"
+             class="save-btn"
+             v-if="saveButtons.generator"
+             :value="i18n('save_changes', 'Save changes')"
+             @click="save"/>
+    </h2>
 
-  <ul class="set">
-    <li v-for="generatorType in allGeneratorTypes">
-      <label><input type="checkbox"
-                    :key="generatorType"
-                    :value="generatorType"
-                    :name="generatorType"
-                    v-model="generator_types"
-                    @change="saveGeneratorTypes">{{ i18n(generatorType) }}</label>
-    </li>
-  </ul>
+    <p>{{ i18n('generator_settings_hint', 'Here you can change the agent switching behavior') }}:</p>
 
-  <h2>{{ i18n('blacklist_settings', 'Blacklist settings') }}</h2>
+    <ul class="set">
+      <li v-for="generatorType in allGeneratorTypes">
+        <label><input type="checkbox"
+                      :key="generatorType"
+                      :value="generatorType"
+                      :name="generatorType"
+                      v-model="settings.generator.types"
+                      @change="saveButtons.generator = true">{{ i18n(generatorType) }}</label>
+      </li>
+    </ul>
 
-  <p>{{
-      i18n('blacklist_settings_hint', 'Blacklist mode - switching enabled everywhere, except the defined domains & rules. Whitelist - on the contrary, disabled everywhere except the specified domains & rules')
-    }}:</p>
-
-  <ul class="list">
-    <list-checkbox :checked="blacklist_mode_whitelist"
-                   :caption="i18n('white_black_list_mode', 'Whitelist mode (blacklist mode - disabled, whitelist mode - enabled)')"
-                   @change="saveBlacklistMode"/>
-    <list-textarea :value="blacklist_domains"
-                   :caption="i18n('blacklist_domains', 'Domain names list (one per line)') + ':'"
-                   placeholder="docs.google.com"
-                   @change="saveBlacklistDomainsList"/>
-    <list-textarea :value="blacklist_custom_rules"
-                   :caption="i18n('blacklist_custom_rules', 'Custom rules (one per line)') + ':'"
-                   placeholder="http?://*google.com/*"
-                   :hint="i18n('blacklist_custom_rules_hint', 'You can use wildcards such as * and ?')"
-                   @change="saveBlacklistCustomRulesList"/>
-  </ul>
-
-  <div v-if="prev_settings">
-    <h3>{{ i18n('previous_settings', 'Previous settings') }} <input type="button"
-                                                                    :value="i18n('remove', 'Remove')"
-                                                                    @click="removePrevSettings"/></h3>
+    <h2>
+      {{ i18n('blacklist_settings', 'Blacklist settings') }}
+      <input type="button"
+             class="save-btn"
+             v-if="saveButtons.blacklist"
+             :value="i18n('save_changes', 'Save changes')"
+             @click="save"/>
+    </h2>
 
     <p>{{
-        i18n('previous_settings_hint', 'These settings were used by you on the previous extension version. Keep it somewhere or remove')
+        i18n('blacklist_settings_hint', 'Blacklist mode - switching enabled everywhere, except the defined domains & rules. Whitelist - on the contrary, disabled everywhere except the specified domains & rules')
       }}:</p>
 
-    <pre>{{ prev_settings }}</pre>
-  </div>
+    <ul class="list">
+      <list-checkbox :checked="settings.blacklist.modeWhitelist"
+                     :caption="i18n('white_black_list_mode', 'Whitelist mode (blacklist mode - disabled, whitelist mode - enabled)')"
+                     @change="value => {settings.blacklist.modeWhitelist = value; saveButtons.blacklist = true}"/>
+      <list-textarea :value="settings.blacklist.domains"
+                     :caption="i18n('blacklist_domains', 'Domain names list (one per line)') + ':'"
+                     placeholder="docs.google.com"
+                     @change="value => {settings.blacklist.domains = value; saveButtons.blacklist = true}"/>
+      <list-textarea :value="settings.blacklist.custom.rules"
+                     :caption="i18n('blacklist_custom_rules', 'Custom rules (one per line)') + ':'"
+                     placeholder="http?://*google.com/*"
+                     :hint="i18n('blacklist_custom_rules_hint', 'You can use wildcards such as * and ?')"
+                     @change="value => {settings.blacklist.custom.rules = value; saveButtons.blacklist = true}"/>
+    </ul>
+
+    <div v-if="prev_settings">
+      <h3>{{ i18n('previous_settings', 'Previous settings') }} <input type="button"
+                                                                      :value="i18n('remove', 'Remove')"
+                                                                      @click="removePrevSettings"/></h3>
+
+      <p>{{
+          i18n('previous_settings_hint', 'These settings were used by you on the previous extension version. Keep it somewhere or remove')
+        }}:</p>
+
+      <pre>{{ prev_settings }}</pre>
+    </div>
+  </article>
 </template>
 
 <script lang="ts">
 import {defineComponent} from 'vue'
 import i18n from './mixins/i18n'
+import OverlayAlert from './components/popup/overlay-alert.vue'
 import ListCheckbox from './components/options/list-checkbox.vue'
 import ListTextarea from './components/options/list-textarea.vue'
 import ListNumber from './components/options/list-number.vue'
 import {RuntimeSender, Sender} from '../messaging/runtime'
 import {getSettings, GetSettingsResponse} from '../messaging/handlers/get-settings'
-import {GeneratorType, isValidType} from '../useragent/generator'
+import {GeneratorType} from '../useragent/generator'
 import {BlacklistMode} from '../settings/settings'
 import {updateSettings} from '../messaging/handlers/update-settings'
 
-const errorsHandler: (err: Error) => void = console.error,
-  backend: Sender = new RuntimeSender
-
-const v2_config_key: string = 'extension_settings_v2'
+const backend: Sender = new RuntimeSender,
+  v2_config_key: string = 'extension_settings_v2'
 
 export default defineComponent({
   components: {
     'list-checkbox': ListCheckbox,
     'list-number': ListNumber,
     'list-textarea': ListTextarea,
+    'overlay-alert': OverlayAlert,
   },
   mixins: [i18n],
   data: (): { [key: string]: any } => {
     return {
-      enabled: false,
-      renew_enabled: false,
-      renew_intervalMillis: 0,
-      renew_onStartup: false,
-      customUseragent_enabled: false,
-      customUseragent_list: [] as string[],
-      jsProtection_enabled: false,
-      generator_types: [] as GeneratorType[],
-      blacklist_mode_whitelist: false,
-      blacklist_domains: [] as string[],
-      blacklist_custom_rules: [] as string[],
+      settings: {
+        enabled: false,
+        renew: {
+          enabled: false,
+          intervalMillis: 0,
+          onStartup: false,
+        },
+        customUseragent: {
+          enabled: false,
+          list: [],
+        },
+        jsProtection: {
+          enabled: false,
+        },
+        generator: {
+          types: [] as GeneratorType[],
+        },
+        blacklist: {
+          modeWhitelist: false,
+          domains: [] as string[],
+          custom: {
+            rules: [] as string[],
+          },
+        },
+      },
 
-      allGeneratorTypes: Object.values(GeneratorType as { [key: string]: string }) as string[],
+      error: {
+        visible: false,
+        message: undefined as string | undefined,
+      },
+
+      saveButtons: { // visibility
+        general: false,
+        generator: false,
+        blacklist: false,
+      },
 
       prev_settings: undefined as string | undefined, // TODO remove this property after a some time
     }
   },
+  computed: {
+    allGeneratorTypes(): string[] {
+      return Object.values(GeneratorType as { [key: string]: string })
+    },
+  },
   methods: {
-    saveEnabled(newState: boolean): void {
-      backend.send(updateSettings({enabled: newState}))
-        .then(() => this.enabled = newState)
-        .catch(errorsHandler)
-    },
-    saveRenewEnabled(newState: boolean): void {
-      backend.send(updateSettings({renew: {enabled: newState}}))
-        .then(() => this.renew_enabled = newState)
-        .catch(errorsHandler)
-    },
-    saveRenewInterval(newValue: number): void {
-      newValue = Math.round(newValue * 1000)
-      backend.send(updateSettings({renew: {intervalMillis: newValue}}))
-        .then(() => this.renew_intervalMillis = newValue)
-        .catch(errorsHandler)
-    },
-    saveRenewOnStartup(newState: boolean): void {
-      backend.send(updateSettings({renew: {onStartup: newState}}))
-        .then(() => this.renew_onStartup = newState)
-        .catch(errorsHandler)
-    },
-    saveJsProtectionEnabled(newState: boolean): void {
-      backend.send(updateSettings({jsProtection: {enabled: newState}}))
-        .then(() => this.jsProtection_enabled = newState)
-        .catch(errorsHandler)
-    },
-    saveCustomUseragentEnabled(newState: boolean): void {
-      backend.send(updateSettings({customUseragent: {enabled: newState}}))
-        .then(() => this.customUseragent_enabled = newState)
-        .catch(errorsHandler)
-    },
-    saveCustomUseragentList(newState: string[]): void {
-      backend.send(updateSettings({customUseragent: {list: newState}}))
-        .then(() => this.customUseragent_list = newState)
-        .catch(errorsHandler)
-    },
-    saveGeneratorTypes(): void {
-      const types = this.generator_types.filter((t): boolean => isValidType(t))
+    handleError(err: Error): void {
+      console.error(err)
 
-      backend.send(updateSettings({generator: {types: types}}))
-        .then(() => this.generator_types = types)
-        .catch(errorsHandler)
+      this.error.message = err.toString()
+      this.error.visible = true
     },
-    saveBlacklistMode(newState: boolean): void {
-      backend.send(updateSettings({blacklist: {mode: newState ? BlacklistMode.WhiteList : BlacklistMode.BlackList}}))
-        .then(() => this.blacklist_mode_whitelist = newState)
-        .catch(errorsHandler)
-    },
-    saveBlacklistDomainsList(newState: string[]): void {
-      backend.send(updateSettings({blacklist: {domains: newState}}))
-        .then(() => this.blacklist_domains = newState)
-        .catch(errorsHandler)
-    },
-    saveBlacklistCustomRulesList(newState: string[]): void {
-      backend.send(updateSettings({blacklist: {custom: {rules: newState}}}))
-        .then(() => this.blacklist_custom_rules = newState)
-        .catch(errorsHandler)
+
+    save(): void {
+      backend
+        .send(updateSettings({
+          enabled: this.settings.enabled,
+          renew: {
+            enabled: this.settings.renew.enabled,
+            intervalMillis: this.settings.renew.intervalMillis,
+            onStartup: this.settings.renew.onStartup,
+          },
+          customUseragent: {
+            enabled: this.settings.customUseragent.enabled,
+            list: this.settings.customUseragent.list.slice(0), // proxy object to the plain array
+          },
+          jsProtection: {
+            enabled: this.settings.jsProtection.enabled,
+          },
+          generator: {
+            types: this.settings.generator.types.slice(0), // proxy object to the plain array
+          },
+          blacklist: {
+            mode: this.settings.blacklist.modeWhitelist ? BlacklistMode.WhiteList : BlacklistMode.BlackList,
+            domains: this.settings.blacklist.domains.slice(0), // proxy object to the plain array
+            custom: {
+              rules: this.settings.blacklist.custom.rules.slice(0), // proxy object to the plain array
+            },
+          },
+        }))
+        .then((): void => {
+          for (const [key] of Object.entries(this.saveButtons)) {
+            this.saveButtons[key] = false
+          }
+        })
+        .catch(this.handleError)
     },
 
     removePrevSettings(): void { // TODO remove this method after a some time
@@ -195,19 +236,19 @@ export default defineComponent({
       .then((resp): void => {
         const settings = (resp[0] as GetSettingsResponse).payload
 
-        this.enabled = settings.enabled
-        this.renew_enabled = settings.renew.enabled
-        this.renew_intervalMillis = settings.renew.intervalMillis
-        this.renew_onStartup = settings.renew.onStartup
-        this.customUseragent_enabled = settings.customUseragent.enabled
-        this.customUseragent_list = settings.customUseragent.list
-        this.jsProtection_enabled = settings.jsProtection.enabled
-        this.generator_types = settings.generator.types
-        this.blacklist_mode_whitelist = settings.blacklist.mode === BlacklistMode.WhiteList
-        this.blacklist_domains = settings.blacklist.domains
-        this.blacklist_custom_rules = settings.blacklist.custom.rules
+        this.settings.enabled = settings.enabled
+        this.settings.renew.enabled = settings.renew.enabled
+        this.settings.renew.intervalMillis = settings.renew.intervalMillis
+        this.settings.renew.onStartup = settings.renew.onStartup
+        this.settings.customUseragent.enabled = settings.customUseragent.enabled
+        this.settings.customUseragent.list = settings.customUseragent.list
+        this.settings.jsProtection.enabled = settings.jsProtection.enabled
+        this.settings.generator.types = settings.generator.types
+        this.settings.blacklist.modeWhitelist = settings.blacklist.mode === BlacklistMode.WhiteList
+        this.settings.blacklist.domains = settings.blacklist.domains
+        this.settings.blacklist.custom.rules = settings.blacklist.custom.rules
       })
-      .catch(errorsHandler)
+      .catch(this.handleError)
 
     try { // TODO remove this block after a some time
       // load the prev extension settings
@@ -224,18 +265,6 @@ export default defineComponent({
       console.warn(e)
     }
   },
-  mounted(): void {
-    // start state refresher
-    window.setInterval((): void => {
-      backend
-        .send(getSettings())
-        .then((resp): void => {
-          const settings = (resp[0] as GetSettingsResponse).payload
-          this.enabled = settings.enabled
-        })
-        .catch(errorsHandler)
-    }, 500) // twice in a one second
-  },
 })
 </script>
 
@@ -244,11 +273,12 @@ export default defineComponent({
   --options-main-bg-color: #fff;
   --options-main-text-color: #111;
   --options-scrollbar-color: #aaa;
-  --options-rows-separator-color: #eee;
+  --options-second-bg-color: #eee;
   --options-input-border-color: #ccc;
   --options-placeholder-color: #bbb;
   --options-hint-color: #666;
   --options-scrollbar-width: 8px;
+  --options-shadow-color: rgba(0, 0, 0, 0.2);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -256,10 +286,11 @@ export default defineComponent({
     --options-main-bg-color: #23222b;
     --options-main-text-color: #fbfbfe;
     --options-scrollbar-color: #666;
-    --options-rows-separator-color: #4e4d54;
+    --options-second-bg-color: #4e4d54;
     --options-input-border-color: #5e5c65;
     --options-placeholder-color: #777;
     --options-hint-color: #aaa;
+    --options-shadow-color: rgba(200, 200, 200, 0.3);
   }
 }
 
@@ -286,8 +317,14 @@ html, body {
   color: var(--options-main-text-color);
 }
 
-body {
+article {
   padding: 0 2em;
+}
+
+.save-btn {
+  margin-left: .5em;
+  padding: 0 1em;
+  box-shadow: 0 0 12px -2px var(--options-shadow-color);
 }
 
 ul {
@@ -299,7 +336,7 @@ ul {
       padding: 1em 0;
 
       &:not(:last-child) {
-        border: solid var(--options-rows-separator-color);
+        border: solid var(--options-second-bg-color);
         border-width: 0 0 1px 0;
       }
     }


### PR DESCRIPTION
## Description

### Added

- "Save changes" button on the options page

### Changed

- Custom user-agent list on the settings page now limited (maximal `4096` symbols are allowed, [the reason is QUOTA_BYTES_PER_ITEM](https://developer.chrome.com/docs/extensions/reference/storage/#property-sync))

### Fixed

- `extraHeaders` options bug for `onHeadersReceived` hook in FireFox

Linked issue: #172

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
