### PR TITLE
Keyboard shortcut to user-agent renewal added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Added
 
-- Keyboard shortcut to user-agent renewal (`Ctrl+Shift+U` by default)
+- Keyboard shortcut to user-agent renewal (`Ctrl+Shift+U` by default) [#289], [#352]
+
+[#289]:https://github.com/tarampampam/random-user-agent/issues/289
+[#352]:https://github.com/tarampampam/random-user-agent/pull/352
 
 ## v3.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## UNRELEASED
+
+### Added
+
+- Keyboard shortcut to user-agent renewal (`Ctrl+Shift+U` by default)
+
 ## v3.11.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ This may occur because your User-Agent simulates MacOS - in this case, some webs
 key instead of the `ctrl`. For fixing this issue just disable MacOS User-Agent in the extension generator settings.
 </details>
 
+<details>
+  <summary>Are keyboard shortcuts supported?</summary>
+
+Yes, but at this moment only one shortcut is supported - user-agent renewal (`Ctrl+Shift+U` by default). You can
+change it in your browser settings: <chrome://extensions/shortcuts> in Google Chrome.
+</details>
+
 ## 🧩 Install
 
 Follow up by one of the links at the top 👆 of this page, or download `CRX`/`XPI` file directly the latest release from the

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -11,6 +11,7 @@
         "message": "Randomisiere deinen User-Agent",
         "description": "The tooltip, or title, appears when the user hovers the mouse on the extension's icon in the toolbar"
     },
+    "manifest_command_renew_useragent": {"message": "Neuen Agent anfordern"},
 
     "active_user_agent": { "message": "Aktiver User-Agent" },
     "pause_switcher": { "message": "Switcher pausieren" },

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -11,6 +11,7 @@
     "message": "Randomize your User-Agent",
     "description": "The tooltip, or title, appears when the user hovers the mouse on the extension's icon in the toolbar"
   },
+  "manifest_command_renew_useragent": {"message": "Get new agent"},
 
   "active_user_agent": {"message": "Active User-Agent"},
   "pause_switcher": {"message": "Pause Switcher"},

--- a/public/_locales/pt_BR/messages.json
+++ b/public/_locales/pt_BR/messages.json
@@ -11,6 +11,7 @@
     "message": "Randomize seu Agente de usuário",
     "description": "The tooltip, or title, appears when the user hovers the mouse on the extension's icon in the toolbar"
   },
+  "manifest_command_renew_useragent": {"message": "Alterar para outro Agente"},
 
   "active_user_agent": {"message": "Agente de usuário ativo"},
   "pause_switcher": {"message": "Pausar alteração"},

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -11,6 +11,7 @@
     "message": "Рандомизировать ваш User-Agent",
     "description": "The tooltip, or title, appears when the user hovers the mouse on the extension's icon in the toolbar"
   },
+  "manifest_command_renew_useragent": {"message": "Установить новый"},
 
   "active_user_agent": {"message": "Текущий User-Agent"},
   "pause_switcher": {"message": "Приостановить подмену"},

--- a/public/_locales/vi/messages.json
+++ b/public/_locales/vi/messages.json
@@ -11,6 +11,7 @@
     "message": "Randomize của bạn User-Agent",
     "description": "The tooltip, or title, appears when the user hovers the mouse on the extension's icon in the toolbar"
   },
+  "manifest_command_renew_useragent": {"message": "Nhận đại lý mới"},
 
   "active_user_agent": {"message": "Tác nhân người dùng hoạt động"},
   "pause_switcher": {"message": "Tạm dừng Switcher"},

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -11,6 +11,7 @@
     "message": "随机化您的 User-Agent",
     "description": "The tooltip, or title, appears when the user hovers the mouse on the extension's icon in the toolbar"
   },
+  "manifest_command_renew_useragent": {"message": "换个新的"},
 
   "active_user_agent": {"message": "活动 User-Agent"},
   "pause_switcher": {"message": "暂停切换器"},

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -40,5 +40,14 @@
     "webRequest",
     "webRequestBlocking",
     "<all_urls>"
-  ]
+  ],
+
+  "commands": {
+    "renew-useragent": {
+      "description": "__MSG_manifest_command_renew_useragent__",
+      "suggested_key": {
+        "default": "Ctrl+Shift+U"
+      }
+    }
+  }
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -21,6 +21,7 @@ import UpdateUseragent from './messaging/handlers/update-useragent'
 import HeadersReceived from './hooks/headers-received'
 import RemoteListService, {LocalStorageStringsCache} from './services/remotelist-service'
 import UpdateRemoteUAList from './messaging/handlers/update-remote-ua-list'
+import OnCommand from './hooks/commands'
 
 // define default errors handler for the background page
 const errorsHandler: (err: Error) => void = console.error
@@ -167,6 +168,9 @@ useragent.load().then((): void => { // load useragent state
 
         // this hook allows to send important data to the content script without using sendMessage()
         new HeadersReceived(settings, useragent, filterService).listen()
+
+        // this hook allows handle keyboard shortcuts
+        new OnCommand(useragentService).listen()
       }).catch(errorsHandler)
     }).catch(errorsHandler)
   }).catch(errorsHandler)

--- a/src/hooks/commands.ts
+++ b/src/hooks/commands.ts
@@ -1,0 +1,26 @@
+import UseragentService from '../services/useragent-service'
+
+export default class OnCommand {
+  private readonly useragentService: UseragentService
+
+  constructor(useragentService: UseragentService) {
+    this.useragentService = useragentService
+  }
+
+  /**
+   * @link https://developer.chrome.com/docs/extensions/reference/commands/
+   */
+  listen(): void {
+    enum Commands {
+      renewUseragent = 'renew-useragent'
+    }
+
+    chrome.commands.onCommand.addListener((command) => {
+      switch (command) {
+        case Commands.renewUseragent:
+          this.useragentService.renew()
+          break
+      }
+    })
+  }
+}


### PR DESCRIPTION
## Description

### Added

- Keyboard shortcut to user-agent renewal (`Ctrl+Shift+U` by default)

Fixes #289

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I wrote unit tests for my code _(if tests are required for my changes)_ <!-- feel free to drop this item from the list -->
- [x] I have made changes in the `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `Added` / `Changed` / `Fixed` sections
* Add a reference to the related issue or this PR `[#123](https://github.com/.../.../(issues|pull)/123)`

-->
