### PR TITLE
Displaying current user-agent on extension icon hover added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## UNRELEASED
+
+### Added
+
+- Displaying current user-agent on extension icon hover [#364]
+
+[#364]:https://github.com/tarampampam/random-user-agent/issues/364
+
 ## v3.14.2
 
 ### Fixed

--- a/src/background.ts
+++ b/src/background.ts
@@ -22,6 +22,7 @@ import HeadersReceived from './hooks/headers-received'
 import RemoteListService, {LocalStorageStringsCache} from './services/remotelist-service'
 import UpdateRemoteUAList from './messaging/handlers/update-remote-ua-list'
 import OnCommand from './hooks/commands'
+import {setExtensionTitle} from './utils/icon-title'
 
 // define default errors handler for the background page
 const errorsHandler: (err: Error) => void = console.error
@@ -33,7 +34,15 @@ const useragent = new Useragent()
 
 useragent.load().then((): void => { // load useragent state
   useragent.on(UseragentStateEvent.onChange, (): void => {
-    useragent.save().catch(errorsHandler) // save useragent state on update
+    useragent.save()
+      .then((): void => {
+        const info = useragent.get().info
+
+        if (info) {
+          setExtensionTitle(info.useragent).catch(errorsHandler)
+        }
+      })
+      .catch(errorsHandler) // save useragent state on update
   })
 
   storage.init().then((): void => { // storage must be initialized before usage

--- a/src/utils/icon-title.ts
+++ b/src/utils/icon-title.ts
@@ -1,0 +1,11 @@
+export async function setExtensionTitle(title:string, tabId?: number) {
+  const details: chrome.browserAction.TitleDetails = {
+    title: title,
+  }
+
+  if (typeof tabId === 'number') {
+    details.tabId = tabId
+  }
+
+  await chrome.browserAction.setTitle(details)
+}

--- a/src/utils/icon-title.ts
+++ b/src/utils/icon-title.ts
@@ -1,4 +1,4 @@
-export async function setExtensionTitle(title:string, tabId?: number) {
+export async function setExtensionTitle(title: string, tabId?: number) {
   const details: chrome.browserAction.TitleDetails = {
     title: title,
   }


### PR DESCRIPTION
## Description

### Added

- Displaying current user-agent on extension icon hover

Fixes #364

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I wrote unit tests for my code _(if tests are required for my changes)_ <!-- feel free to drop this item from the list -->
- [x] I have made changes in the `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `Added` / `Changed` / `Fixed` sections
* Add a reference to the related issue or this PR `[#123](https://github.com/.../.../(issues|pull)/123)`

-->
