### PR TITLE
Fix whitelist rules for top-level navigation

### DIFF
--- a/src/entrypoints/background/hooks/http-requests.test.ts
+++ b/src/entrypoints/background/hooks/http-requests.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { setRequestHeaders } from './http-requests'
+import type { ReadonlyUserAgentState } from '~/shared/types'
+
+const userAgent: ReadonlyUserAgentState = {
+  userAgent:
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36',
+  browser: 'chrome',
+  os: 'macOS',
+  version: { browser: { major: 139, full: '139.0.0.0' } },
+}
+
+const installChromeMock = () => {
+  const updateDynamicRules = vi.fn().mockResolvedValue(undefined)
+
+  vi.stubGlobal('chrome', {
+    declarativeNetRequest: {
+      ResourceType: {
+        MAIN_FRAME: 'main_frame',
+        SCRIPT: 'script',
+      },
+      updateDynamicRules,
+    },
+  })
+
+  return updateDynamicRules
+}
+
+describe('setRequestHeaders', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  test('allows whitelist rules to match a top-level navigation', async () => {
+    const updateDynamicRules = installChromeMock()
+    const rules = await setRequestHeaders(userAgent, { applyToDomains: ['lcps.aodianyun.com'] }, true)
+
+    expect(rules).toHaveLength(3)
+    for (const rule of rules) {
+      expect(rule.condition.requestDomains).toEqual(['lcps.aodianyun.com'])
+      expect(rule.condition).not.toHaveProperty('initiatorDomains')
+    }
+    expect(updateDynamicRules).toHaveBeenCalledWith({
+      removeRuleIds: [1, 2, 3],
+      addRules: rules,
+    })
+  })
+
+  test('keeps blacklist exclusions on both request and initiator domains', async () => {
+    installChromeMock()
+    const rules = await setRequestHeaders(userAgent, { exceptDomains: ['example.com'] })
+
+    for (const rule of rules) {
+      expect(rule.condition.excludedRequestDomains).toContain('example.com')
+      expect(rule.condition.excludedInitiatorDomains).toContain('example.com')
+    }
+  })
+})

--- a/src/entrypoints/background/hooks/http-requests.ts
+++ b/src/entrypoints/background/hooks/http-requests.ts
@@ -81,7 +81,9 @@ export async function setRequestHeaders(
     const list = filter.applyToDomains.map(canonizeDomain).filter(validateDomainOrIP)
 
     if (list.length) {
-      condition.initiatorDomains = condition.requestDomains = list
+      // A top-level navigation has no initiator. Restricting the rule with both
+      // fields prevents the payload from reaching pages opened directly.
+      condition.requestDomains = list
     }
   }
 


### PR DESCRIPTION
## Summary
- remove the `initiatorDomains` constraint from whitelist request rules
- add regression coverage for top-level navigation and preserve blacklist exclusions

## Why
A direct top-level navigation has no request initiator. Combining `initiatorDomains` and `requestDomains` prevented the whitelist response payload from reaching directly opened pages, so JavaScript UA protection did not run even though the popup reported a domain match.

## Validation
- `vitest --run --logHeapUsage --dir ./src` (912 tests passed)
- `tsc --noEmit`
- `eslint ./src/**/*.{ts,tsx}`
- `vite build`